### PR TITLE
Make AsmSpy prefer 64-bit process

### DIFF
--- a/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
+++ b/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
@@ -16,6 +16,7 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
It fails to load ARM64 assemblies on ADO build agents but not in local builds. This is an experiment to see if forcing it to always run in a 64-bit process will fix the problem on the build agents.