### PR TITLE
Change -e parameter from starts with to full match

### DIFF
--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -43,7 +43,7 @@ namespace AsmSpy.CommandLine
             nonsystem = command.Option("-n|--nonsystem", "Ignore 'System' assemblies", CommandOptionType.NoValue);
             all = command.Option("-a|--all", "List all assemblies and references.", CommandOptionType.NoValue);
             referencedStartsWith = command.Option("-rsw|--referencedstartswith", "Referenced Assembly should start with <string>. Will only analyze assemblies if their referenced assemblies starts with the given value.", CommandOptionType.SingleValue);
-            excludeAssemblies = command.Option("-e|--exclude", "A partial assembly name which should be excluded. This option can be provided multiple times", CommandOptionType.MultipleValue);
+            excludeAssemblies = command.Option("-e|--exclude", "Exclude assembly with given name. This option can be provided multiple times", CommandOptionType.MultipleValue);
             includeSubDirectories = command.Option("-i|--includesub", "Include subdirectories in search", CommandOptionType.NoValue);
             configurationFile = command.Option("-c|--configurationFile", "Use the binding redirects of the given configuration file (Web.config or App.config)", CommandOptionType.SingleValue);
             failOnMissing = command.Option("-f|--failOnMissing", "Whether to exit with an error code when AsmSpy detected Assemblies which could not be found", CommandOptionType.NoValue);

--- a/AsmSpy.Core/DependencyAnalyzer.cs
+++ b/AsmSpy.Core/DependencyAnalyzer.cs
@@ -215,7 +215,7 @@ namespace AsmSpy.Core
                 return null;
             }
 
-            if (options.Exclude.Any(e => assemblyName.FullName.StartsWith(e, StringComparison.OrdinalIgnoreCase)))
+            if (options.Exclude.Any(e => assemblyName.Name.Equals(e, StringComparison.OrdinalIgnoreCase)))
             {
                 return null;
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Build
+
+```
+nuget restore
+dotnet build
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It will output a list of all conflicting assembly references. That is where diff
 | dot | Export dependency graph to a [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) file.<br> Supported formats:  -dt \<filename\> |
 | xml | Export dependency graph to a xml file.<br> Supported formats:  -x \<filename\> |
 | rsw | Will only analyze assemblies if their referenced assemblies starts with the given value.<br> Supported formats:  -rsw \<string\>, --referencedstartswith \<string\> |
-| e | Will exclude assemblies if they start with the given value. This option can be provided multiple times.<br> Supported formats:  -e \<string\>, --exclude \<string\> |
+| e | Will exclude assemblies the given name. This option can be provided multiple times.<br> Supported formats:  -e \<string\>, --exclude \<string\> |
 | tree | Write a dependency tree to the console.<br>Supported formats: -tr --tree |
 | treedepth | Limit tree depth (in compbinaison with --tree). Supported formats : -trd \<int\> --treedepth \<int\> |
 | treelabel | Add [Level n] label in tree view of dependencies. Supported formats -trl --treelabel |


### PR DESCRIPTION
We place System.Fabric in the GAC, but don't want to exclude all other System.Fabric.* assemblies that should be loaded from application code base.